### PR TITLE
add matrix project support to release plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.399</version>
+    <version>1.481</version>
   </parent>
   <artifactId>release</artifactId>
   <packaging>hpi</packaging>

--- a/src/main/java/hudson/plugins/release/ReleaseWrapper.java
+++ b/src/main/java/hudson/plugins/release/ReleaseWrapper.java
@@ -55,6 +55,8 @@ import hudson.tasks.BuildWrapper;
 import hudson.tasks.BuildWrapperDescriptor;
 import hudson.tasks.Builder;
 import hudson.util.VariableResolver;
+import hudson.matrix.MatrixProject;
+import hudson.matrix.MatrixChildAction;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -381,7 +383,7 @@ public class ReleaseWrapper extends BuildWrapper {
         
         @Override
         public boolean isApplicable(AbstractProject<?, ?> item) {
-            return FreeStyleProject.class.isInstance(item) || MavenModuleSet.class.isInstance(item);
+            return FreeStyleProject.class.isInstance(item) || MavenModuleSet.class.isInstance(item) || MatrixProject.class.isInstance(item);
         }
     }
 
@@ -610,7 +612,7 @@ public class ReleaseWrapper extends BuildWrapper {
 
     }
     
-    public static class ReleaseBuildBadgeAction implements BuildBadgeAction {
+    public static class ReleaseBuildBadgeAction implements BuildBadgeAction, MatrixChildAction {
         private String releaseVersion;
         
         public ReleaseBuildBadgeAction() {


### PR DESCRIPTION
Make ReleaseBadgeAction implement MatrixChildAction so that it isn't filtered out in DefaultMatrixExecutionStrategyImpl when configuration jobs are scheduled
