### PR TITLE
JENKINS-20797 Use Cause.UserIdCause, not deprecated Cause.UserCause

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ target
 *.ipr
 *.iws
 work
+.idea
+

--- a/src/main/java/hudson/plugins/release/ReleaseWrapper.java
+++ b/src/main/java/hudson/plugins/release/ReleaseWrapper.java
@@ -206,7 +206,7 @@ public class ReleaseWrapper extends BuildWrapper implements MatrixAggregatable {
     }
     
     /**
-     * @param preBuildSteps The preMatrixBuildSteps to set.
+     * @param preMatrixBuildSteps The preMatrixBuildSteps to set.
      */
     public void setPreMatrixBuildSteps(List<Builder> preMatrixBuildSteps) {
         this.preMatrixBuildSteps = preMatrixBuildSteps;
@@ -220,7 +220,7 @@ public class ReleaseWrapper extends BuildWrapper implements MatrixAggregatable {
     }
     
     /**
-     * @param postBuildSteps The postBuildSteps to set.
+     * @param postSuccessBuildSteps The postBuildSteps to set.
      */
     public void setPostBuildSteps(List<Builder> postSuccessBuildSteps) {
         this.postBuildSteps = postSuccessBuildSteps;
@@ -665,7 +665,7 @@ public class ReleaseWrapper extends BuildWrapper implements MatrixAggregatable {
             }
             
             // schedule release build
-            if (!project.scheduleBuild(0, new Cause.UserCause(), 
+            if (!project.scheduleBuild(0, new Cause.UserIdCause(),
             		new ReleaseBuildBadgeAction(), 
             		new ParametersAction(paramValues))) {
             	// TODO redirect to error page?
@@ -710,7 +710,7 @@ public class ReleaseWrapper extends BuildWrapper implements MatrixAggregatable {
         }
 
         /**
-         * @param preBuildSteps The preMatrixBuildSteps to set.
+         * @param preMatrixBuildSteps The preMatrixBuildSteps to set.
          */
         public void setPreMatrixBuildSteps(List<Builder> preMatrixBuildSteps) {
             this.preMatrixBuildSteps = preMatrixBuildSteps;

--- a/src/main/java/hudson/plugins/release/dashboard/RecentReleasesPortlet.java
+++ b/src/main/java/hudson/plugins/release/dashboard/RecentReleasesPortlet.java
@@ -9,7 +9,6 @@ import hudson.model.Job;
 import hudson.model.RSS;
 import hudson.model.Run;
 import hudson.model.User;
-import hudson.model.Cause.UserCause;
 import hudson.plugins.release.ReleaseWrapper.ReleaseBuildBadgeAction;
 import hudson.plugins.view.dashboard.DashboardPortlet;
 import hudson.tasks.Mailer;
@@ -162,12 +161,12 @@ public class RecentReleasesPortlet extends DashboardPortlet {
         }
 
         public String getEntryAuthor(Run entry) {
-        	// release builds are manual so get the UserCause
+        	// release builds are manual so get the UserIdCause
         	// and report rss entry as user who kicked off build
         	List<Cause> causes = entry.getCauses();
         	for (Cause cause : causes) {
-        		if (cause instanceof UserCause) {
-        			return User.get(((UserCause) cause).getUserName()).getFullName();
+        		if (cause instanceof Cause.UserIdCause) {
+        			return User.get(((Cause.UserIdCause) cause).getUserName()).getFullName();
         		}
         	}
         	


### PR DESCRIPTION
Switch to use Cause.UserIdCause, this will help build-user-vars-plugin when a release happens. Cause.UserCause is deprecated as well.

Also ignore .idea folder, and fix some javadoc warnings.