### PR TITLE
Set the description for the parent build when running a matrix build

### DIFF
--- a/src/main/java/hudson/plugins/release/ReleaseWrapper.java
+++ b/src/main/java/hudson/plugins/release/ReleaseWrapper.java
@@ -346,7 +346,7 @@ public class ReleaseWrapper extends BuildWrapper implements MatrixAggregatable {
 
                                 if (build instanceof MatrixRun) {
                                        // also set the description for the parent if the build is a matrix one
-                                       ((MatrixRun) build).getParentBuild().setDescription("1." + releaseBuildBadge.getReleaseVersion());
+                                       ((MatrixRun) build).getParentBuild().setDescription(releaseBuildBadge.getReleaseVersion());
                                 }
                         }
 


### PR DESCRIPTION
I made a small change to the release plugin so that the release version set as a description is also set on the parent build when running a matrix job.

Note: Thanks for creating this plugin, it's extremely useful !
