### PR TITLE
defined a new specific RELEASE permission which is distinct from the sta...

### DIFF
--- a/src/main/java/hudson/plugins/release/ReleaseWrapper.java
+++ b/src/main/java/hudson/plugins/release/ReleaseWrapper.java
@@ -51,6 +51,9 @@ import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.StringParameterValue;
 import hudson.plugins.release.promotion.ReleasePromotionCondition;
+import hudson.security.Permission;
+import hudson.security.PermissionGroup;
+import hudson.security.PermissionScope;
 import hudson.tasks.BuildStep;
 import hudson.tasks.BuildWrapper;
 import hudson.tasks.BuildWrapperDescriptor;
@@ -88,6 +91,14 @@ import org.kohsuke.stapler.StaplerResponse;
  * @since 1.0
  */
 public class ReleaseWrapper extends BuildWrapper implements MatrixAggregatable {
+
+    public static final PermissionGroup PERMISSIONS = new PermissionGroup(ReleaseWrapper.class, Messages._ReleaseWrapper_PermissionsTitle());
+
+    /**
+     * Permission to trigger release builds.
+     */
+    public static final Permission RELEASE_PERMISSION = new Permission(PERMISSIONS,"Release",Messages._ReleaseWrapper_ReleasePermission_Description(),null, PermissionScope.ITEM);
+
     private static final String DEFAULT_RELEASE_VERSION_TEMPLATE = "Release #$RELEASE_VERSION";
 	
     private String releaseVersionTemplate;
@@ -411,11 +422,11 @@ public class ReleaseWrapper extends BuildWrapper implements MatrixAggregatable {
     }
     
 	public static boolean hasReleasePermission(AbstractProject job) {
-		return job.hasPermission(Item.BUILD) && !MatrixConfiguration.class.isInstance(job);
+		return job.hasPermission(RELEASE_PERMISSION) && !MatrixConfiguration.class.isInstance(job);
 	}
 
 	public static void checkReleasePermission(AbstractProject job) {
-		job.checkPermission(Item.BUILD);
+		job.checkPermission(RELEASE_PERMISSION);
 	}
     
 	@Extension

--- a/src/main/resources/hudson/plugins/release/Messages.properties
+++ b/src/main/resources/hudson/plugins/release/Messages.properties
@@ -1,17 +1,17 @@
 # The MIT License
-# 
+#
 # Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Seiji Sogabe, Frederic Gurr
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -24,4 +24,6 @@ ReleaseWrapper.ConfigureReleaseBuild=Configure release build
 ReleaseWrapper.CouldNotExecutePreBuildSteps=Could not execute pre-build steps
 ReleaseWrapper.LastReleaseBuild=Last release build
 ReleaseWrapper.LastSuccessfulReleaseBuild=Last successful release build
+ReleaseWrapper.PermissionsTitle=Release
+ReleaseWrapper.ReleasePermission_Description=This permission allows users to trigger a release build.
 ReleaseButtonColumn.DisplayName=Release Button

--- a/src/main/resources/hudson/plugins/release/Messages_de.properties
+++ b/src/main/resources/hudson/plugins/release/Messages_de.properties
@@ -1,17 +1,17 @@
 # The MIT License
-# 
+#
 # Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Simon Wiest
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -24,4 +24,6 @@ ReleaseWrapper.ConfigureReleaseBuild=Release Build konfigurieren
 ReleaseWrapper.CouldNotExecutePreBuildSteps=Pre-Build-Schritte konnten nicht ausgef\u00FChrt werden
 ReleaseWrapper.LastReleaseBuild=Letzter Release Build
 ReleaseWrapper.LastSuccessfulReleaseBuild=Letzter erfolgreicher Release Build
+ReleaseWrapper.PermissionsTitle=Release
+# To be translated: ReleaseWrapper.ReleasePermission_Description=This permission allows users to trigger a release build.
 ReleaseButtonColumn.DisplayName=Release Knopf

--- a/src/main/resources/hudson/plugins/release/ReleaseButtonColumn/column.jelly
+++ b/src/main/resources/hudson/plugins/release/ReleaseButtonColumn/column.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
       <td>
-          <j:if test="${job.buildable and job.hasPermission(job.BUILD) and it.isReleaseConfigured(job)}">
+          <j:if test="${job.buildable and job.hasPermission(hudson.plugins.release.ReleaseWrapper.RELEASE_PERMISSION) and it.isReleaseConfigured(job)}">
               <a href="${jobBaseUrl}${job.shortUrl}release">
                   <img src="${imagesURL}/${subIconSize}/package.png"
                        title="${%Release}" alt="${%Release}"


### PR DESCRIPTION
...ndard BUILD permission. This allows to fine tune access permissions: not all users allowed to trigger a build should be allowed to trigger a release build.

Note: This commit introduces a breaking change since upgrading to a newer plugin version including this feature will automatically revoke release permissions from existing users (they'll just be able to build, not release). Admins will have to grant the release permissions back again.
