### PR TITLE
Defined 2 custom view job filters 'All Release Jobs' and 'Release Jobs'....

### DIFF
--- a/src/main/java/hudson/plugins/release/AllReleaseJobsFilter.java
+++ b/src/main/java/hudson/plugins/release/AllReleaseJobsFilter.java
@@ -1,0 +1,77 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2014, Francois Ritaly / Calypso Technology
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.release;
+
+import hudson.Extension;
+import hudson.model.TopLevelItem;
+import hudson.model.Descriptor;
+import hudson.model.View;
+import hudson.views.ViewJobFilter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Custom view job filter used for adding all jobs with the release wrapper
+ * configured to a view.
+ *
+ * @author francois_ritaly
+ */
+public class AllReleaseJobsFilter extends ViewJobFilter {
+
+	@DataBoundConstructor
+	public AllReleaseJobsFilter() {
+	}
+
+	@Override
+	public List<TopLevelItem> filter(List<TopLevelItem> added, List<TopLevelItem> all, View filteringView) {
+		final List<TopLevelItem> selection = new ArrayList<TopLevelItem>(added);
+
+		// Complete the incoming added list with all jobs using the 'release' wrapper
+		for (final TopLevelItem item : all) {
+			if (ViewJobFilterUtils.isReleaseJob(item)) {
+				if (!selection.contains(item)) {
+					selection.add(item);
+				}
+			}
+		}
+
+		return selection;
+	}
+
+	@Extension
+	public static class DescriptorImpl extends Descriptor<ViewJobFilter> {
+		@Override
+		public String getDisplayName() {
+			return Messages.AllReleaseJobsFilter_DisplayName();
+		}
+
+        @Override
+        public String getHelpFile() {
+            return "/plugin/release/view-filter/help-allReleaseJobs.html";
+        }
+	}
+}

--- a/src/main/java/hudson/plugins/release/ReleaseJobsFilter.java
+++ b/src/main/java/hudson/plugins/release/ReleaseJobsFilter.java
@@ -1,0 +1,75 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2014, Francois Ritaly / Calypso Technology
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.release;
+
+import hudson.Extension;
+import hudson.model.TopLevelItem;
+import hudson.model.Descriptor;
+import hudson.model.View;
+import hudson.views.ViewJobFilter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Custom view job filter used for filtering (that is keeping) all jobs with the
+ * release wrapper configured.
+ *
+ * @author francois_ritaly
+ */
+public class ReleaseJobsFilter extends ViewJobFilter {
+
+	@DataBoundConstructor
+	public ReleaseJobsFilter() {
+	}
+
+	@Override
+	public List<TopLevelItem> filter(List<TopLevelItem> added, List<TopLevelItem> all, View filteringView) {
+		final List<TopLevelItem> selection = new ArrayList<TopLevelItem>();
+
+		// Filter the 'added' list to only keep the jobs using the release wrapper
+		for (final TopLevelItem item : added) {
+			if (ViewJobFilterUtils.isReleaseJob(item)) {
+				selection.add(item);
+			}
+		}
+
+		return selection;
+	}
+
+	@Extension
+	public static class DescriptorImpl extends Descriptor<ViewJobFilter> {
+		@Override
+		public String getDisplayName() {
+			return Messages.ReleaseJobsFilter_DisplayName();
+		}
+
+        @Override
+        public String getHelpFile() {
+            return "/plugin/release/view-filter/help-releaseJobs.html";
+        }
+	}
+}

--- a/src/main/java/hudson/plugins/release/ViewJobFilterUtils.java
+++ b/src/main/java/hudson/plugins/release/ViewJobFilterUtils.java
@@ -1,0 +1,55 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2014, Francois Ritaly / Calypso Technology
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.release;
+
+import hudson.model.BuildableItemWithBuildWrappers;
+import hudson.model.TopLevelItem;
+
+import org.apache.commons.lang.Validate;
+
+final class ViewJobFilterUtils {
+
+	private ViewJobFilterUtils() {
+	}
+
+	/**
+	 * Tells whether the given top level item is a release job, that is, a job
+	 * configured to use the 'release' build wrapper.
+	 *
+	 * @param item
+	 *            a top level item to test. Can't be null.
+	 * @return whether the given top level item is a release job.
+	 */
+	static boolean isReleaseJob(TopLevelItem item) {
+		Validate.notNull(item, "The given top level item is null");
+
+		if (item instanceof BuildableItemWithBuildWrappers) {
+			final BuildableItemWithBuildWrappers job = (BuildableItemWithBuildWrappers) item;
+
+			return (job.getBuildWrappersList().get(ReleaseWrapper.class) != null);
+		}
+
+		return false;
+	}
+}

--- a/src/main/resources/hudson/plugins/release/Messages.properties
+++ b/src/main/resources/hudson/plugins/release/Messages.properties
@@ -27,3 +27,5 @@ ReleaseWrapper.LastSuccessfulReleaseBuild=Last successful release build
 ReleaseWrapper.PermissionsTitle=Release
 ReleaseWrapper.ReleasePermission_Description=This permission allows users to trigger a release build.
 ReleaseButtonColumn.DisplayName=Release Button
+ReleaseJobsFilter.DisplayName=Release Jobs
+AllReleaseJobsFilter.DisplayName=All Release Jobs

--- a/src/main/resources/hudson/plugins/release/Messages_de.properties
+++ b/src/main/resources/hudson/plugins/release/Messages_de.properties
@@ -27,3 +27,5 @@ ReleaseWrapper.LastSuccessfulReleaseBuild=Letzter erfolgreicher Release Build
 ReleaseWrapper.PermissionsTitle=Release
 # To be translated: ReleaseWrapper.ReleasePermission_Description=This permission allows users to trigger a release build.
 ReleaseButtonColumn.DisplayName=Release Knopf
+# To be translated: ReleaseJobsFilter.DisplayName=Release Jobs
+# To be translated: AllReleaseJobsFilter.DisplayName=All Release Jobs

--- a/src/main/webapp/view-filter/help-allReleaseJobs.html
+++ b/src/main/webapp/view-filter/help-allReleaseJobs.html
@@ -1,0 +1,3 @@
+<div>
+Adds to the view all the jobs using the 'release' build wrapper.
+</div>

--- a/src/main/webapp/view-filter/help-releaseJobs.html
+++ b/src/main/webapp/view-filter/help-releaseJobs.html
@@ -1,0 +1,3 @@
+<div>
+Filters the view to only keep the jobs using the 'release' build wrapper.
+</div>


### PR DESCRIPTION
... The first filter will alter the selection of a list view to include all the jobs using the release plugin. The second filter will alter the selection of a list view to only keep the jobs using the release plugin.

Those filters will help in creating views to quickly list release jobs in jenkins.
