### PR TITLE
Fixing bad override translation.

### DIFF
--- a/src/main/resources/hudson/plugins/release/ReleaseWrapper/ReleaseAction/index_fr.properties
+++ b/src/main/resources/hudson/plugins/release/ReleaseWrapper/ReleaseAction/index_fr.properties
@@ -24,5 +24,5 @@
 Next\ development\ version=Prochaine version de d\u00e9veloppement
 Release\ version=Version de la release
 Schedule\ Release\ Build=Programmer le build de la release
-Override\ build\ parameters=Surcharge des param\u00e8tres du build
+Override\ build\ parameters=Redéfinition des param\u00e8tres du build
 Define\ release=D\u00e9finition de la release

--- a/src/main/resources/hudson/plugins/release/ReleaseWrapper/config_fr.properties
+++ b/src/main/resources/hudson/plugins/release/ReleaseWrapper/config_fr.properties
@@ -24,6 +24,6 @@
 Add\ Parameter=Ajouter un param\u00e8tre
 Add\ release\ step=Ajouter une \u00e9tape de distribution
 Before\ release\ build=Avant le build de distribution
-Override\ build\ parameters=Surcharger les param\u00e8tres du build
+Override\ build\ parameters=Redéfinir les param\u00e8tres du build
 Release\ Version\ Template=Template de version de distribution
 Release\ parameters=Param\u00e8tres de la distribution


### PR DESCRIPTION
In french, override translates to "redéfinir", not "surcharger".
