### PR TITLE
Allow both Publishers and Builders within the actions for a release

### DIFF
--- a/src/main/resources/hudson/plugins/release/ReleaseWrapper/config.jelly
+++ b/src/main/resources/hudson/plugins/release/ReleaseWrapper/config.jelly
@@ -58,7 +58,7 @@
 			<!-- Pre build steps -->
 			<label class="attach-previous">${%Before release build}</label>
                         <f:hetero-list name="preBuildSteps" hasHeader="true"
-                             descriptors="${h.getPublisherDescriptors(it)}"
+                             descriptors="${instance.getBuildSteps(it)}"
                              items="${instance.preBuildSteps}"
                              addCaption="${%Add release step}"/>
                 </div>
@@ -72,7 +72,7 @@
 			<!-- Post successful build steps -->
 			<label class="attach-previous">${%After successful release build}</label>
                         <f:hetero-list name="postSuccessfulBuildSteps" hasHeader="true"
-                             descriptors="${h.getPublisherDescriptors(it)}"
+                             descriptors="${instance.getBuildSteps(it)}"
                              items="${instance.postSuccessfulBuildSteps}"
                              addCaption="${%Add release step}"/>
                 </div>
@@ -86,7 +86,7 @@
 			<!-- Post failed build steps -->
 			<label class="attach-previous">${%After failed release build}</label>
                         <f:hetero-list name="postFailedBuildSteps" hasHeader="true"
-                             descriptors="${h.getPublisherDescriptors(it)}"
+                             descriptors="${instance.getBuildSteps(it)}"
                              items="${instance.postFailedBuildSteps}"
                              addCaption="${%Add release step}"/>
                 </div>
@@ -100,7 +100,7 @@
 		    <!-- Post build steps -->
 		    <label class="attach-previous">${%After failed or successful release build}</label>
 		    <f:hetero-list name="postBuildSteps" hasHeader="true"
-		             descriptors="${h.getPublisherDescriptors(it)}"
+		             descriptors="${instance.getBuildSteps(it)}"
 		             items="${instance.postBuildSteps}"
 		             addCaption="${%Add release step}"/>
                 </div>
@@ -115,7 +115,7 @@
 			<!-- Pre matrix build steps -->
 			<label class="attach-previous">${%Before release build and all matrix configurations}</label>
                         <f:hetero-list name="preMatrixBuildSteps" hasHeader="true"
-                             descriptors="${h.getPublisherDescriptors(it)}"
+                             descriptors="${instance.getBuildSteps(it)}"
                              items="${instance.preMatrixBuildSteps}"
                              addCaption="${%Add release step}"/>
                 </div>
@@ -141,7 +141,7 @@
 			<!-- Post failed build steps -->
 			<label class="attach-previous">${%After failed release build and all matrix configurations}</label>
                         <f:hetero-list name="postFailedMatrixBuildSteps" hasHeader="true"
-                             descriptors="${h.getPublisherDescriptors(it)}"
+                             descriptors="${instance.getBuildSteps(it)}"
                              items="${instance.postFailedMatrixBuildSteps}"
                              addCaption="${%Add release step}"/>
                 </div>
@@ -155,7 +155,7 @@
 		    <!-- Post build steps -->
 		    <label class="attach-previous">${%After failed or successful release build and all matrix configurations}</label>
 		    <f:hetero-list name="postBuildSteps" hasHeader="true"
-		             descriptors="${h.getPublisherDescriptors(it)}"
+		             descriptors="${instance.getBuildSteps(it)}"
 		             items="${instance.postBuildSteps}"
 		             addCaption="${%Add release step}"/>
                 </div>


### PR DESCRIPTION
The main reason for this change was my desire to have tasks that were post-build actions(Publisher) to be done during the "After successful release build" phase but only during a release, and not during a normal build.

I changed the actions allowed to show both Publishers and Builders, and adjusted the code to handle the base class, BuildStep.
