### PR TITLE
JENKINS-27722 - fix for previous merge that could stop plugin working on some jobs

### DIFF
--- a/src/main/java/hudson/plugins/release/ReleaseWrapper.java
+++ b/src/main/java/hudson/plugins/release/ReleaseWrapper.java
@@ -169,19 +169,7 @@ public class ReleaseWrapper extends BuildWrapper implements MatrixAggregatable {
      */
     public ReleaseWrapper() {
     }
-    
-    public List<Descriptor> getBuildSteps(AbstractProject<?,?> project)
-    {
-        List<Descriptor<Publisher>> publishers = Functions.getPublisherDescriptors(project);
-        List<Descriptor<Builder>> builders = Functions.getBuilderDescriptors(project);
-        
-        List<Descriptor> descriptors = new LinkedList<Descriptor>();
-        descriptors.addAll(publishers);
-        descriptors.addAll(builders);
-        
-        return descriptors;
-    }
-    
+       
     public String getReleaseVersionTemplate() {
         return releaseVersionTemplate;
     }

--- a/src/main/java/hudson/plugins/release/ReleaseWrapperHelper.java
+++ b/src/main/java/hudson/plugins/release/ReleaseWrapperHelper.java
@@ -1,0 +1,35 @@
+/*
+ * 
+ */
+package hudson.plugins.release;
+
+import hudson.Functions;
+import hudson.model.AbstractProject;
+import hudson.model.Descriptor;
+import hudson.tasks.Builder;
+import hudson.tasks.Publisher;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Helper class
+ */
+public class ReleaseWrapperHelper
+{
+    /** Retrieve a list of all build steps including publishers and builders 
+     * 
+     * @param project The project
+     * @return A list of descriptor's for both publishers and builders
+     */
+    static public List<Descriptor> getBuildSteps(AbstractProject<?,?> project)
+    {
+        List<Descriptor<Publisher>> publishers = Functions.getPublisherDescriptors(project);
+        List<Descriptor<Builder>> builders = Functions.getBuilderDescriptors(project);
+        
+        List<Descriptor> descriptors = new LinkedList<Descriptor>();
+        descriptors.addAll(publishers);
+        descriptors.addAll(builders);
+        
+        return descriptors;
+    }
+}

--- a/src/main/resources/hudson/plugins/release/ReleaseWrapper/config.jelly
+++ b/src/main/resources/hudson/plugins/release/ReleaseWrapper/config.jelly
@@ -27,6 +27,11 @@
          xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
          xmlns:p="/lib/hudson/project">
 	
+    <!-- Due to bug JENKINS-26579 we can't just call j:new, we have to use this workaround to get an instance of the helper class
+	that we can then use to call the static method getBuildSteps()
+     -->
+    <j:set var="h2" value="${app.pluginManager.uberClassLoader.loadClass('hudson.plugins.release.ReleaseWrapperHelper').newInstance()}"/>	
+
     <f:entry title="${%Release Version Template}" help="/plugin/release/help-releaseVersionTemplate.html">
         <f:textbox field="releaseVersionTemplate" />
     </f:entry>
@@ -58,7 +63,7 @@
 			<!-- Pre build steps -->
 			<label class="attach-previous">${%Before release build}</label>
                         <f:hetero-list name="preBuildSteps" hasHeader="true"
-                             descriptors="${instance.getBuildSteps(it)}"
+                             descriptors="${h2.getBuildSteps(it)}"
                              items="${instance.preBuildSteps}"
                              addCaption="${%Add release step}"/>
                 </div>
@@ -72,7 +77,7 @@
 			<!-- Post successful build steps -->
 			<label class="attach-previous">${%After successful release build}</label>
                         <f:hetero-list name="postSuccessfulBuildSteps" hasHeader="true"
-                             descriptors="${instance.getBuildSteps(it)}"
+                             descriptors="${h2.getBuildSteps(it)}"
                              items="${instance.postSuccessfulBuildSteps}"
                              addCaption="${%Add release step}"/>
                 </div>
@@ -86,7 +91,7 @@
 			<!-- Post failed build steps -->
 			<label class="attach-previous">${%After failed release build}</label>
                         <f:hetero-list name="postFailedBuildSteps" hasHeader="true"
-                             descriptors="${instance.getBuildSteps(it)}"
+                             descriptors="${h2.getBuildSteps(it)}"
                              items="${instance.postFailedBuildSteps}"
                              addCaption="${%Add release step}"/>
                 </div>
@@ -100,7 +105,7 @@
 		    <!-- Post build steps -->
 		    <label class="attach-previous">${%After failed or successful release build}</label>
 		    <f:hetero-list name="postBuildSteps" hasHeader="true"
-		             descriptors="${instance.getBuildSteps(it)}"
+		             descriptors="${h2.getBuildSteps(it)}"
 		             items="${instance.postBuildSteps}"
 		             addCaption="${%Add release step}"/>
                 </div>
@@ -115,7 +120,7 @@
 			<!-- Pre matrix build steps -->
 			<label class="attach-previous">${%Before release build and all matrix configurations}</label>
                         <f:hetero-list name="preMatrixBuildSteps" hasHeader="true"
-                             descriptors="${instance.getBuildSteps(it)}"
+                             descriptors="${h2.getBuildSteps(it)}"
                              items="${instance.preMatrixBuildSteps}"
                              addCaption="${%Add release step}"/>
                 </div>
@@ -141,7 +146,7 @@
 			<!-- Post failed build steps -->
 			<label class="attach-previous">${%After failed release build and all matrix configurations}</label>
                         <f:hetero-list name="postFailedMatrixBuildSteps" hasHeader="true"
-                             descriptors="${instance.getBuildSteps(it)}"
+                             descriptors="${h2.getBuildSteps(it)}"
                              items="${instance.postFailedMatrixBuildSteps}"
                              addCaption="${%Add release step}"/>
                 </div>
@@ -155,7 +160,7 @@
 		    <!-- Post build steps -->
 		    <label class="attach-previous">${%After failed or successful release build and all matrix configurations}</label>
 		    <f:hetero-list name="postBuildSteps" hasHeader="true"
-		             descriptors="${instance.getBuildSteps(it)}"
+		             descriptors="${h2.getBuildSteps(it)}"
 		             items="${instance.postBuildSteps}"
 		             addCaption="${%Add release step}"/>
                 </div>

--- a/src/test/java/hudson/plugins/release/TestReleasePlugin.java
+++ b/src/test/java/hudson/plugins/release/TestReleasePlugin.java
@@ -1,0 +1,36 @@
+package hudson.plugins.release;
+
+import hudson.PluginWrapper;
+import hudson.model.Descriptor;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test the general integration of the plugin with Jenkins/Hudson and ensure the plugin is registered properly and is active
+ */
+public class TestReleasePlugin
+{
+	@Rule
+	public JenkinsRule j = new JenkinsRule();
+
+	@Test
+	public void testPluginActive() throws Exception
+	{
+		// Check if the plugin is loaded and active
+		PluginWrapper plugin = j.getPluginManager().getPlugin("release");
+		assertTrue("Plugin not active", plugin.isActive());
+	}
+
+	@Test
+	public void testDescriptorRegistered() throws Exception
+	{
+		Descriptor<?> descriptor = Descriptor.find(ReleaseWrapper.DescriptorImpl.class.getName());
+		assertNotNull("Must have ReleaseWrapper descriptor", descriptor);
+	}
+
+}

--- a/src/test/java/hudson/plugins/release/TestReleasePluginJob.java
+++ b/src/test/java/hudson/plugins/release/TestReleasePluginJob.java
@@ -1,0 +1,110 @@
+package hudson.plugins.release;
+
+import com.gargoylesoftware.htmlunit.html.HtmlCheckBoxInput;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+
+import org.jvnet.hudson.test.JenkinsRule;
+
+import hudson.model.*;
+import hudson.plugins.release.ReleaseWrapper;
+import hudson.plugins.release.ReleaseWrapper.ReleaseAction;
+import hudson.tasks.BuildWrapper;
+import hudson.util.DescribableList;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.Rule;
+
+/**
+ * Test the general integration of the plugin with Jenkins/Hudson and ensure it gets added properly and correctly add it's links/buttons etc to the
+ * required pages.
+ */
+public class TestReleasePluginJob
+{
+	@Rule
+	public JenkinsRule j = new JenkinsRule();
+
+	FreeStyleProject job;
+
+	@Before
+	public void createJob() throws Exception
+	{
+		job = j.createFreeStyleProject("test");
+	}
+
+	@After
+	public void deleteJob() throws Exception
+	{
+		job.delete();
+	}
+
+	@Test
+	public void testPermission() throws Exception
+	{
+		// Check if the user has permission to release
+		assertTrue("No permission", ReleaseWrapper.hasReleasePermission(job));
+	}
+
+	@Test
+	public void testInBuilders() throws Exception
+	{
+		// Check the job has the ReleaseWrapper listed in it's builders, AND that it it listed in the project actions
+		enableReleaseBuilder();
+		DescribableList<BuildWrapper, Descriptor<BuildWrapper>> buildWrappersList = job.getBuildWrappersList();
+		Descriptor<BuildWrapper> descriptor = Descriptor.find(ReleaseWrapper.DescriptorImpl.class.getName());
+		BuildWrapper buildWrapper = buildWrappersList.get(descriptor);
+		assertNotNull(buildWrapper);
+		Collection<? extends Action> actions = buildWrapper.getProjectActions(job);
+		assertNotNull("Actions can't be null", actions);
+		assertThat("Must have actions", actions.size(), not(0));
+	}
+
+	@Test
+	public void testInActions() throws Exception
+	{
+		// Check that the job has an action listed when release is enabled
+		enableReleaseBuilder();
+		assertNotNull("Must have action", job.getAction(ReleaseAction.class));
+	}
+
+	@Test
+	public void testEnableReleaseUsingWebPage() throws Exception
+	{
+		enableReleaseBuilder();
+
+		/** Check if the Release links exist */
+		HtmlPage page = j.createWebClient().goTo("job/test/");
+		// Internationalisation not needed because the URL doesn't change between languages
+		// see getUrlName() in ReleaseAction
+		List<Object> nodes = page.selectNodes("//a[contains(@href, '/test/release')]");
+		assertThat("Require 2 href links", nodes.size(), is(2));
+	}
+
+	/** Enable the release builder by adding it to the job */
+	private void enableReleaseBuilder() throws Exception
+	{
+		/** Enable the release plugin for the job */
+		HtmlForm configForm = j.createWebClient().getPage(job, "configure").getFormByName("config");
+		assertThat(configForm, notNullValue());
+
+		// not sure if internationalisation required for this?
+		HtmlCheckBoxInput releaseCheckButton = configForm.getInputByName("hudson-plugins-release-ReleaseWrapper");
+		assertThat("No Release Check Button found", releaseCheckButton, notNullValue());
+		releaseCheckButton.setChecked(true);
+		j.submit(configForm);
+	}
+
+}


### PR DESCRIPTION
A previous pull request ( https://github.com/jenkinsci/release-plugin/pull/11 ) contained an error that could cause the release-plugin to not show configuration items under certain circumstances.

This request fixes that error and also introduces unit tests to ensure that the Release plugin correctly registers itself with Jenkins and also checks that the plugin correctly renders a 'Release' link on the job page and release checkbox on the configuration page.

See also: https://issues.jenkins-ci.org/browse/JENKINS-27722