### PR TITLE
Enable release plugin for ivy plugin with optional dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target
 *.iws
 *.idea
 work
+/bin/

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,12 @@
         <artifactId>matrix-project</artifactId>
         <version>1.7</version>
     </dependency>
+    <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>ivy</artifactId>
+        <version>1.22</version>
+        <optional>true</optional>
+    </dependency>
   </dependencies>
 
 

--- a/src/main/java/hudson/plugins/release/ReleaseWrapper.java
+++ b/src/main/java/hudson/plugins/release/ReleaseWrapper.java
@@ -31,6 +31,7 @@ import hudson.ExtensionList;
 import hudson.Functions;
 import hudson.Launcher;
 import hudson.Util;
+import hudson.ivy.IvyModuleSet;
 import hudson.matrix.MatrixRun;
 import hudson.maven.MavenModuleSet;
 import hudson.model.AbstractBuild;
@@ -80,12 +81,12 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import javax.servlet.ServletException;
-import jenkins.model.Jenkins;
 
+import jenkins.model.Jenkins;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.ArrayUtils;
 
+import org.apache.commons.lang.ArrayUtils;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
@@ -465,8 +466,15 @@ public class ReleaseWrapper extends BuildWrapper implements MatrixAggregatable {
         
         @Override
         public boolean isApplicable(AbstractProject<?, ?> item) {
-            return FreeStyleProject.class.isInstance(item) || MavenModuleSet.class.isInstance(item) || MatrixProject.class.isInstance(item);
+            return FreeStyleProject.class.isInstance(item) || MavenModuleSet.class.isInstance(item) || MatrixProject.class.isInstance(item) || isApplicableFor3rdParty(item);
         }
+        
+        private boolean isApplicableFor3rdParty(AbstractProject<?, ?> item) {
+            if (Jenkins.getInstance().getPlugin("ivy") != null) {
+                return IvyModuleSet.class.isInstance(item);
+            }
+            return false;
+        } 
 
         public boolean isMatrixProject(AbstractProject<?, ?> item) {
             return MatrixProject.class.isInstance(item);

--- a/src/main/java/hudson/plugins/release/ReleaseWrapper.java
+++ b/src/main/java/hudson/plugins/release/ReleaseWrapper.java
@@ -470,10 +470,14 @@ public class ReleaseWrapper extends BuildWrapper implements MatrixAggregatable {
         }
         
         private boolean isApplicableFor3rdParty(AbstractProject<?, ?> item) {
-            if (Jenkins.getInstance().getPlugin("ivy") != null) {
-                return IvyModuleSet.class.isInstance(item);
+        	boolean isApplicable = false;
+            Jenkins jenkinsInstance = Jenkins.getInstance();
+            if (jenkinsInstance != null){
+                if (jenkinsInstance.getPlugin("ivy") != null) {
+                    isApplicable = IvyModuleSet.class.isInstance(item);
+                }
             }
-            return false;
+            return isApplicable;
         } 
 
         public boolean isMatrixProject(AbstractProject<?, ?> item) {


### PR DESCRIPTION
**Add release functionality to 3rd party plugins without code dependency**
There are two plugins that could also benefit from release funtionality:
- Ivy Plugin

I integrated the functionality to these plguins without getting dependency to the plugin code.
