### PR TITLE
JENKINS-11176 Promotion criteria "If the build is a release build" is broken and displays duplicated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ target
 *.iml
 *.ipr
 *.iws
+*.idea
 work

--- a/src/main/java/hudson/plugins/release/ReleaseWrapper.java
+++ b/src/main/java/hudson/plugins/release/ReleaseWrapper.java
@@ -437,14 +437,6 @@ public class ReleaseWrapper extends BuildWrapper implements MatrixAggregatable {
     
 	@Extension
     public static final class DescriptorImpl extends BuildWrapperDescriptor {
-
-        static {
-            // check if promoted plugins is installed and if so, register
-            // promotion condition
-            if (Hudson.getInstance().getPlugin("promoted-builds") != null) {
-                    ReleasePromotionCondition.registerExtension();
-            }
-        }
         
         @Override
         public String getDisplayName() {

--- a/src/main/java/hudson/plugins/release/promotion/ReleasePromotionCondition.java
+++ b/src/main/java/hudson/plugins/release/promotion/ReleasePromotionCondition.java
@@ -5,6 +5,7 @@
 
 package hudson.plugins.release.promotion;
 
+import hudson.Extension;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.plugins.promoted_builds.PromotionBadge;
@@ -30,14 +31,20 @@ public class ReleasePromotionCondition extends PromotionCondition {
         return null;
     }
 
+    /**
+     * Register a new instance of {@link PromotionConditionDescriptor} to this {@link PromotionCondition}
+     *
+     * @deprecated Caused duplication of descriptor (see JENKINS-11176). Replaced by the Extension annotation in
+     * the {@link PromotionConditionDescriptor}.
+     */
+    @Deprecated
+    public static void registerExtension() {}
+
     public static final class Badge extends PromotionBadge {
         
     }
 
-    public static void registerExtension() {
-        PromotionCondition.all().add(new DescriptorImpl());
-    }
-
+    @Extension(optional = true)
     public static final class DescriptorImpl extends PromotionConditionDescriptor {
 
         public boolean isApplicable(AbstractProject<?,?> item) {

--- a/src/test/java/hudson/plugins/release/TestReleasePlugin.java
+++ b/src/test/java/hudson/plugins/release/TestReleasePlugin.java
@@ -3,6 +3,7 @@ package hudson.plugins.release;
 import hudson.PluginWrapper;
 import hudson.model.Descriptor;
 
+import hudson.plugins.release.promotion.ReleasePromotionCondition;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -33,4 +34,10 @@ public class TestReleasePlugin
 		assertNotNull("Must have ReleaseWrapper descriptor", descriptor);
 	}
 
+	@Test
+	public void testPromotionDescriptorRegistered() throws Exception
+	{
+		Descriptor<?> descriptor = Descriptor.find(ReleasePromotionCondition.DescriptorImpl.class.getName());
+		assertNotNull("Must have ReleaseWrapper descriptor", descriptor);
+	}
 }


### PR DESCRIPTION
Fixed [JENKINS-11176](https://issues.jenkins-ci.org/browse/JENKINS-11176) that duplicates the Release promotion condition (Duplicate descriptors).

@reviewbybees 