### PR TITLE
[FIXED JENKINS-28132] add an impliedBy definition to permission

### DIFF
--- a/src/main/java/hudson/plugins/release/ReleaseWrapper.java
+++ b/src/main/java/hudson/plugins/release/ReleaseWrapper.java
@@ -103,7 +103,7 @@ public class ReleaseWrapper extends BuildWrapper implements MatrixAggregatable {
     /**
      * Permission to trigger release builds.
      */
-    public static final Permission RELEASE_PERMISSION = new Permission(PERMISSIONS,"Release",Messages._ReleaseWrapper_ReleasePermission_Description(),null, PermissionScope.ITEM);
+    public static final Permission RELEASE_PERMISSION = new Permission(PERMISSIONS,"Release",Messages._ReleaseWrapper_ReleasePermission_Description(),Jenkins.ADMINISTER, PermissionScope.ITEM);
 
     private static final String DEFAULT_RELEASE_VERSION_TEMPLATE = "Release #$RELEASE_VERSION";
 	


### PR DESCRIPTION
Add impliedBy definition to release permission so it will be handled properly if no matrix-based security is used