### PR TITLE
[JENKINS-40765] add pipeline support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Release+Plugin</url>
 
   <properties>
-    <jenkins.version>1.609.3</jenkins.version>
-    <java.level>6</java.level>
+    <!-- https://issues.jenkins-ci.org/browse/JENKINS-29692  https://issues.jenkins-ci.org/browse/JENKINS-28781 -->
+    <jenkins.version>1.642.4</jenkins.version>
   </properties>
 
   <scm>
@@ -60,6 +60,41 @@
         <artifactId>ivy</artifactId>
         <version>1.22</version>
         <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-step-api</artifactId>
+      <version>2.3</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-support</artifactId>
+      <version>2.6</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps</artifactId>
+      <version>2.9</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+      <version>2.9</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>ant</artifactId>
+      <version>1.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-basic-steps</artifactId>
+      <version>2.1</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>release</artifactId>
   <packaging>hpi</packaging>
   <name>Jenkins Release Plugin</name>
-  <version>2.6.2-SNAPSHOT</version>
+  <version>2.7-SNAPSHOT</version>
   <description>Adds the ability to wrap your job with pre- and post- build steps which are only executed when a manual release build is triggered.</description>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Release+Plugin</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-support</artifactId>
       <version>2.6</version>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/hudson/plugins/release/SafeParametersAction.java
+++ b/src/main/java/hudson/plugins/release/SafeParametersAction.java
@@ -1,7 +1,6 @@
 package hudson.plugins.release;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 
 import org.kohsuke.accmod.Restricted;
@@ -18,40 +17,15 @@ import hudson.model.TaskListener;
 @Restricted(NoExternalUse.class)
 public class SafeParametersAction extends ParametersAction {
 
-    private final List<ParameterValue> parameters;
-
     /**
      * At this point the list of parameter values is guaranteed to be safe, which is
      * parameter defined either at top level or release wrapper level.
+     *
      * @param parameters parameters allowed by the job and parameters allowed by release-specific parameters definition
      * @since 2.7 - public constructor
      */
     public SafeParametersAction(List<ParameterValue> parameters) {
-        this.parameters = parameters;
-    }
-
-    /**
-     * Returns all parameters allowed by the job (defined as regular job parameters) and
-     * the parameters allowed by release-specific parameters definition.
-     */
-    @Override
-    public List<ParameterValue> getParameters() {
-        return Collections.unmodifiableList(parameters);
-    }
-
-    /**
-     * Returns the parameter if defined as a regular parameters or it is a release-specific parameter defined
-     * by the release wrapper.
-     */
-    @Override
-    public ParameterValue getParameter(String name) {
-        for (ParameterValue p : parameters) {
-            if (p == null) continue;
-            if (p.getName().equals(name)) {
-                return p;
-            }
-        }
-        return null;
+        super(parameters);
     }
 
     @Extension
@@ -61,7 +35,7 @@ public class SafeParametersAction extends ParametersAction {
         public void buildEnvironmentFor(Run r, EnvVars envs, TaskListener listener) throws IOException, InterruptedException {
             SafeParametersAction action = r.getAction(SafeParametersAction.class);
             if (action != null) {
-                for(ParameterValue p : action.getParameters()) {
+                for (ParameterValue p : action.getParameters()) {
                     envs.put(p.getName(), String.valueOf(p.getValue()));
                 }
             }

--- a/src/main/java/hudson/plugins/release/SafeParametersAction.java
+++ b/src/main/java/hudson/plugins/release/SafeParametersAction.java
@@ -24,6 +24,7 @@ public class SafeParametersAction extends ParametersAction {
      * At this point the list of parameter values is guaranteed to be safe, which is
      * parameter defined either at top level or release wrapper level.
      * @param parameters parameters allowed by the job and parameters allowed by release-specific parameters definition
+     * @since 2.7 - public constructor
      */
     public SafeParametersAction(List<ParameterValue> parameters) {
         this.parameters = parameters;

--- a/src/main/java/hudson/plugins/release/SafeParametersAction.java
+++ b/src/main/java/hudson/plugins/release/SafeParametersAction.java
@@ -23,8 +23,9 @@ public class SafeParametersAction extends ParametersAction {
     /**
      * At this point the list of parameter values is guaranteed to be safe, which is
      * parameter defined either at top level or release wrapper level.
+     * @param parameters parameters allowed by the job and parameters allowed by release-specific parameters definition
      */
-    SafeParametersAction(List<ParameterValue> parameters) {
+    public SafeParametersAction(List<ParameterValue> parameters) {
         this.parameters = parameters;
     }
 

--- a/src/main/java/hudson/plugins/release/pipeline/ReleaseQueueListener.java
+++ b/src/main/java/hudson/plugins/release/pipeline/ReleaseQueueListener.java
@@ -1,0 +1,23 @@
+package hudson.plugins.release.pipeline;
+
+import hudson.AbortException;
+import hudson.Extension;
+import hudson.model.Queue;
+import hudson.model.queue.QueueListener;
+
+/**
+ * copied from org.jenkinsci.plugins.workflow.support.steps.build.BuildQueueListener
+ */
+@Extension
+public class ReleaseQueueListener extends QueueListener {
+    @Override
+    public void onLeft(Queue.LeftItem li) {
+        if(li.isCancelled()){
+            for (ReleaseTriggerAction.Trigger trigger : ReleaseTriggerAction.triggersFor(li)) {
+                trigger.context.onFailure(new AbortException("Build of " + li.task.getFullDisplayName() + " was cancelled"));
+            }
+        }
+    }
+
+
+}

--- a/src/main/java/hudson/plugins/release/pipeline/ReleaseQueueListener.java
+++ b/src/main/java/hudson/plugins/release/pipeline/ReleaseQueueListener.java
@@ -1,5 +1,8 @@
 package hudson.plugins.release.pipeline;
 
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
 import hudson.AbortException;
 import hudson.Extension;
 import hudson.model.Queue;
@@ -7,14 +10,16 @@ import hudson.model.queue.QueueListener;
 
 /**
  * copied from org.jenkinsci.plugins.workflow.support.steps.build.BuildQueueListener
+ * @since 2.7
  */
 @Extension
+@Restricted(NoExternalUse.class)
 public class ReleaseQueueListener extends QueueListener {
     @Override
     public void onLeft(Queue.LeftItem li) {
         if(li.isCancelled()){
             for (ReleaseTriggerAction.Trigger trigger : ReleaseTriggerAction.triggersFor(li)) {
-                trigger.context.onFailure(new AbortException("Build of " + li.task.getFullDisplayName() + " was cancelled"));
+                trigger.context.onFailure(new AbortException("Pipeline Release plugin: build of " + li.task.getFullDisplayName() + " was cancelled"));
             }
         }
     }

--- a/src/main/java/hudson/plugins/release/pipeline/ReleaseStep.java
+++ b/src/main/java/hudson/plugins/release/pipeline/ReleaseStep.java
@@ -1,0 +1,218 @@
+package hudson.plugins.release.pipeline;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.annotation.Nonnull;
+
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+import org.jenkinsci.plugins.workflow.util.StaplerReferer;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
+import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+
+import com.google.inject.Inject;
+
+import hudson.AbortException;
+import hudson.Extension;
+import hudson.console.ModelHyperlinkNote;
+import hudson.model.AbstractProject;
+import hudson.model.Action;
+import hudson.model.AutoCompletionCandidates;
+import hudson.model.BuildableItemWithBuildWrappers;
+import hudson.model.Cause;
+import hudson.model.ItemGroup;
+import hudson.model.Job;
+import hudson.model.ParameterDefinition;
+import hudson.model.ParameterValue;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.model.queue.QueueTaskFuture;
+import hudson.plugins.release.ReleaseWrapper;
+import hudson.plugins.release.SafeParametersAction;
+import jenkins.model.Jenkins;
+import jenkins.model.ParameterizedJobMixIn;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+
+/**
+ * Created by e3cmea on 1/3/17.
+ *
+ * @author Alexey Merezhin
+ */
+public class ReleaseStep extends AbstractStepImpl {
+    private static final Logger LOGGER = Logger.getLogger(ReleaseStep.class.getName());
+
+    private String job;
+    private List<ParameterValue> parameters;
+
+    @DataBoundConstructor
+    public ReleaseStep(String job) {
+        this.job = job;
+        parameters = new ArrayList<>();
+    }
+
+    public String getJob() {
+        return job;
+    }
+
+    public void setJob(String job) {
+        this.job = job;
+    }
+
+    public List<ParameterValue> getParameters() {
+        return parameters;
+    }
+
+    @DataBoundSetter public void setParameters(List<ParameterValue> parameters) {
+        this.parameters = parameters;
+    }
+
+    public static class Execution extends AbstractStepExecutionImpl {
+        @StepContextParameter private transient Run<?,?> invokingRun;
+        @StepContextParameter private transient TaskListener listener;
+
+        @Inject(optional=true) transient ReleaseStep step;
+
+        private List<ParameterValue> updateParametersWithDefaults(AbstractProject project,
+                List<ParameterValue> parameters) throws AbortException {
+
+            if (project instanceof BuildableItemWithBuildWrappers) {
+                ReleaseWrapper wrapper = ((BuildableItemWithBuildWrappers) project).getBuildWrappersList()
+                                                                                   .get(ReleaseWrapper.class);
+                if (wrapper != null) {
+                    for (ParameterDefinition pd : wrapper.getParameterDefinitions()) {
+                        boolean parameterExists = false;
+                        for (ParameterValue pv : parameters) {
+                            if (pv.getName()
+                                  .equals(pd.getName())) {
+                                parameterExists = true;
+                                break;
+                            }
+                        }
+                        if (!parameterExists) {
+                            parameters.add(pd.getDefaultParameterValue());
+                        }
+                    }
+                } else {
+                    throw new AbortException("Job doesn't have release plugin configuration");
+                }
+            }
+            return parameters;
+        }
+
+        @Override
+        public boolean start() throws Exception {
+            if (step.getJob() == null) {
+                throw new AbortException("Job name is not defined.");
+            }
+
+            final AbstractProject project = Jenkins.getActiveInstance()
+                                                   .getItem(step.getJob(), invokingRun.getParent(), AbstractProject.class);
+            if (project == null) {
+                throw new AbortException("No parametrized job named " + step.getJob() + " found");
+            }
+            listener.getLogger().println("Releasing project: " + ModelHyperlinkNote.encodeTo(project));
+
+            List<Action> actions = new ArrayList<>();
+            StepContext context = getContext();
+            actions.add(new ReleaseTriggerAction(context));
+            LOGGER.log(Level.FINER, "scheduling a release of {0} from {1}", new Object[] { project, context });
+            actions.add(new SafeParametersAction(updateParametersWithDefaults(project, step.getParameters())));
+            actions.add(new ReleaseWrapper.ReleaseBuildBadgeAction());
+
+            QueueTaskFuture<?> task = project.scheduleBuild2(0, new Cause.UpstreamCause(invokingRun), actions);
+            if (task == null) {
+                throw new AbortException("Failed to trigger build of " + project.getFullName());
+            }
+
+            return false;
+        }
+
+        @Override
+        public void stop(@Nonnull Throwable cause) throws Exception {
+            getContext().onFailure(cause);
+        }
+
+        private static final long serialVersionUID = 1L;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+        public DescriptorImpl() {
+            super(Execution.class);
+        }
+
+        @Override
+        public String getFunctionName() {
+            return "release";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Trigger release for the job";
+        }
+
+        @Override public Step newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+            ReleaseStep step = (ReleaseStep) super.newInstance(req, formData);
+            // Cf. ParametersDefinitionProperty._doBuild:
+            Object parameter = formData.get("parameter");
+            JSONArray params = parameter != null ? JSONArray.fromObject(parameter) : null;
+            if (params != null) {
+                Jenkins jenkins = Jenkins.getInstance();
+                Job<?,?> context = StaplerReferer.findItemFromRequest(Job.class);
+                Job<?,?> job = jenkins != null ? jenkins.getItem(step.getJob(), context, Job.class) : null;
+
+                AbstractProject project = Jenkins.getActiveInstance()
+                                                       .getItem(step.getJob(), context, AbstractProject.class);
+
+                if (project instanceof BuildableItemWithBuildWrappers) {
+                    ReleaseWrapper wrapper = ((BuildableItemWithBuildWrappers) project).getBuildWrappersList()
+                                                                       .get(ReleaseWrapper.class);
+                    if (wrapper == null) {
+                        throw new IllegalArgumentException("Job doesn't have release plugin configuration");
+                    }
+                    List<ParameterDefinition> parameterDefinitions = wrapper.getParameterDefinitions();
+                    if (parameterDefinitions != null) {
+                        List<ParameterValue> values = new ArrayList<>();
+                        for (Object o : params) {
+                            JSONObject jo = (JSONObject) o;
+                            String name = jo.getString("name");
+                            for (ParameterDefinition pd : parameterDefinitions) {
+                                if (name.equals(pd.getName())) {
+                                    ParameterValue parameterValue = pd.createValue(req, jo);
+                                    values.add(parameterValue);
+                                }
+                            }
+                        }
+                        step.setParameters(values);
+                    }
+                } else {
+                    throw new IllegalArgumentException("Wrong job type: " + project.getClass().getName());
+                }
+            }
+            return step;
+        }
+
+        public AutoCompletionCandidates doAutoCompleteJob(@AncestorInPath ItemGroup<?> context, @QueryParameter String value) {
+            return AutoCompletionCandidates.ofJobNames(ParameterizedJobMixIn.ParameterizedJob.class, value, context);
+        }
+
+        @Restricted(DoNotUse.class) // for use from config.jelly
+        public String getContext() {
+            Job<?,?> job = StaplerReferer.findItemFromRequest(Job.class);
+            return job != null ? job.getFullName() : null;
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/release/pipeline/ReleaseStepExecution.java
+++ b/src/main/java/hudson/plugins/release/pipeline/ReleaseStepExecution.java
@@ -84,11 +84,10 @@ public class ReleaseStepExecution extends StepExecution {
         getContext().get(TaskListener.class).getLogger()
                 .println("Releasing project: " + ModelHyperlinkNote.encodeTo(project));
 
-        StepContext context = getContext();
-        LOGGER.log(Level.FINER, "scheduling a release of {0} from {1}", new Object[] { project, context });
-        Action[] actions = new Action[] { new ReleaseTriggerAction(context),
-                new SafeParametersAction(updateParametersWithDefaults(project, step.getParameters())),
+        LOGGER.log(Level.FINER, "scheduling a release of {0} from {1}", new Object[] { project, getContext() });
+        Action[] actions = new Action[] { new ReleaseTriggerAction(getContext()),
                 new ReleaseWrapper.ReleaseBuildBadgeAction(),
+                new SafeParametersAction(updateParametersWithDefaults(project, step.getParameters())),
                 new CauseAction(new Cause.UpstreamCause(getContext().get(Run.class))) };
 
         Queue.Item item = ParameterizedJobMixIn.scheduleBuild2((Job<?, ?>) project, 0, actions);

--- a/src/main/java/hudson/plugins/release/pipeline/ReleaseStepExecution.java
+++ b/src/main/java/hudson/plugins/release/pipeline/ReleaseStepExecution.java
@@ -1,0 +1,109 @@
+package hudson.plugins.release.pipeline;
+
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.annotation.Nonnull;
+
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+
+import com.google.inject.Inject;
+
+import hudson.AbortException;
+import hudson.console.ModelHyperlinkNote;
+import hudson.model.Action;
+import hudson.model.BuildableItemWithBuildWrappers;
+import hudson.model.Cause;
+import hudson.model.CauseAction;
+import hudson.model.Item;
+import hudson.model.Job;
+import hudson.model.ParameterDefinition;
+import hudson.model.ParameterValue;
+import hudson.model.Queue;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.plugins.release.ReleaseWrapper;
+import hudson.plugins.release.SafeParametersAction;
+import jenkins.model.Jenkins;
+import jenkins.model.ParameterizedJobMixIn;
+
+/**
+ * @author Alexey Merezhin
+ * @since 2.7
+ */
+public class ReleaseStepExecution extends StepExecution {
+    private static final Logger LOGGER = Logger.getLogger(ReleaseStepExecution.class.getName());
+
+    transient ReleaseStep step;
+
+    public ReleaseStepExecution(@Nonnull StepContext context, @Nonnull ReleaseStep step) {
+        super(context);
+        this.step = step;
+    }
+
+    private List<ParameterValue> updateParametersWithDefaults(ParameterizedJobMixIn.ParameterizedJob project,
+            List<ParameterValue> parameters) throws AbortException {
+
+        if (project instanceof BuildableItemWithBuildWrappers) {
+            ReleaseWrapper wrapper = ((BuildableItemWithBuildWrappers) project).getBuildWrappersList()
+                                                                               .get(ReleaseWrapper.class);
+            if (wrapper != null) {
+                for (ParameterDefinition pd : wrapper.getParameterDefinitions()) {
+                    boolean parameterExists = false;
+                    for (ParameterValue pv : parameters) {
+                        if (pv.getName().equals(pd.getName())) {
+                            parameterExists = true;
+                            break;
+                        }
+                    }
+                    if (!parameterExists) {
+                        parameters.add(pd.getDefaultParameterValue());
+                    }
+                }
+            } else {
+                throw new AbortException("Job doesn't have release plugin configuration");
+            }
+        }
+        return parameters;
+    }
+
+    @Override
+    public boolean start() throws Exception {
+        if (step.getJob() == null) {
+            throw new AbortException("Job name is not defined.");
+        }
+
+        final ParameterizedJobMixIn.ParameterizedJob project = Jenkins.getActiveInstance().
+                getItemByFullName(step.getJob(), ParameterizedJobMixIn.ParameterizedJob.class);;
+        if (project == null) {
+            throw new AbortException("No parametrized job named " + step.getJob() + " found");
+        }
+        getContext().get(TaskListener.class).getLogger()
+                .println("Releasing project: " + ModelHyperlinkNote.encodeTo(project));
+
+        StepContext context = getContext();
+        LOGGER.log(Level.FINER, "scheduling a release of {0} from {1}", new Object[] { project, context });
+        Action[] actions = new Action[] { new ReleaseTriggerAction(context),
+                new SafeParametersAction(updateParametersWithDefaults(project, step.getParameters())),
+                new ReleaseWrapper.ReleaseBuildBadgeAction(),
+                new CauseAction(new Cause.UpstreamCause(getContext().get(Run.class))) };
+
+        Queue.Item item = ParameterizedJobMixIn.scheduleBuild2((Job<?, ?>) project, 0, actions);
+
+        if (item == null || item.getFuture() == null) {
+            throw new AbortException("Failed to trigger build of " + project.getFullName());
+        }
+
+        return false;
+    }
+
+    @Override
+    public void stop(@Nonnull Throwable cause) throws Exception {
+        getContext().onFailure(cause);
+    }
+
+    private static final long serialVersionUID = 1L;
+}

--- a/src/main/java/hudson/plugins/release/pipeline/ReleaseStepExecution.java
+++ b/src/main/java/hudson/plugins/release/pipeline/ReleaseStepExecution.java
@@ -1,5 +1,8 @@
 package hudson.plugins.release.pipeline;
 
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -7,10 +10,7 @@ import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 
 import org.jenkinsci.plugins.workflow.steps.StepContext;
-import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
-
-import com.google.inject.Inject;
 
 import hudson.AbortException;
 import hudson.console.ModelHyperlinkNote;
@@ -18,7 +18,6 @@ import hudson.model.Action;
 import hudson.model.BuildableItemWithBuildWrappers;
 import hudson.model.Cause;
 import hudson.model.CauseAction;
-import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.ParameterDefinition;
 import hudson.model.ParameterValue;
@@ -81,22 +80,33 @@ public class ReleaseStepExecution extends StepExecution {
         if (project == null) {
             throw new AbortException("No parametrized job named " + step.getJob() + " found");
         }
-        getContext().get(TaskListener.class).getLogger()
-                .println("Releasing project: " + ModelHyperlinkNote.encodeTo(project));
+        println("Releasing project: " + ModelHyperlinkNote.encodeTo(project));
 
         LOGGER.log(Level.FINER, "scheduling a release of {0} from {1}", new Object[] { project, getContext() });
-        Action[] actions = new Action[] { new ReleaseTriggerAction(getContext()),
-                new ReleaseWrapper.ReleaseBuildBadgeAction(),
-                new SafeParametersAction(updateParametersWithDefaults(project, step.getParameters())),
-                new CauseAction(new Cause.UpstreamCause(getContext().get(Run.class))) };
+        Run run = getContext().get(Run.class);
+        List<Action> actions = new ArrayList<>(3);
+        actions.add(new ReleaseTriggerAction(getContext()));
+        actions.add(new ReleaseWrapper.ReleaseBuildBadgeAction());
+        actions.add(new SafeParametersAction(updateParametersWithDefaults(project, step.getParameters())));
+        if (run != null) {
+            actions.add(new CauseAction(new Cause.UpstreamCause(run)));
+        }
 
-        Queue.Item item = ParameterizedJobMixIn.scheduleBuild2((Job<?, ?>) project, 0, actions);
+        Queue.Item item = ParameterizedJobMixIn.scheduleBuild2((Job<?, ?>) project, 0, actions.toArray(new Action[0]));
 
         if (item == null || item.getFuture() == null) {
             throw new AbortException("Failed to trigger build of " + project.getFullName());
         }
 
         return false;
+    }
+
+    private void println(String message) throws IOException, InterruptedException {
+        TaskListener taskListener = getContext().get(TaskListener.class);
+        if (taskListener == null) return;
+        PrintStream taskLogger = taskListener.getLogger();
+        if (taskLogger == null) return;
+        taskLogger.println(message);
     }
 
     @Override

--- a/src/main/java/hudson/plugins/release/pipeline/ReleaseTriggerAction.java
+++ b/src/main/java/hudson/plugins/release/pipeline/ReleaseTriggerAction.java
@@ -2,24 +2,18 @@ package hudson.plugins.release.pipeline;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import javax.annotation.CheckForNull;
 
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 
-import hudson.model.Action;
 import hudson.model.Actionable;
 import hudson.model.InvisibleAction;
-import hudson.model.Queue;
-import hudson.model.queue.FoldableAction;
 
 /**
  * copied from org.jenkinsci.plugins.workflow.support.steps.build.BuildTriggerAction
  * @since 2.7
  */
-@SuppressWarnings("SynchronizeOnNonFinalField")
 class ReleaseTriggerAction extends InvisibleAction {
     /** Record of one upstream build step. */
     static class Trigger {
@@ -35,7 +29,7 @@ class ReleaseTriggerAction extends InvisibleAction {
 
     }
 
-    private /* final */ List<Trigger> triggers;
+    private final List<Trigger> triggers;
 
     ReleaseTriggerAction(StepContext context) {
         triggers = new ArrayList<>();
@@ -44,7 +38,7 @@ class ReleaseTriggerAction extends InvisibleAction {
 
     static Iterable<Trigger> triggersFor(Actionable actionable) {
         List<Trigger> triggers = new ArrayList<>();
-        for (ReleaseTriggerAction action : actionable.getActions(ReleaseTriggerAction.class)) {
+        for (final ReleaseTriggerAction action : actionable.getActions(ReleaseTriggerAction.class)) {
             if (!action.triggers.isEmpty()) {
                 synchronized (action.triggers) {
                     triggers.addAll(action.triggers);

--- a/src/main/java/hudson/plugins/release/pipeline/ReleaseTriggerAction.java
+++ b/src/main/java/hudson/plugins/release/pipeline/ReleaseTriggerAction.java
@@ -17,14 +17,12 @@ import hudson.model.queue.FoldableAction;
 
 /**
  * copied from org.jenkinsci.plugins.workflow.support.steps.build.BuildTriggerAction
+ * @since 2.7
  */
 @SuppressWarnings("SynchronizeOnNonFinalField")
 class ReleaseTriggerAction extends InvisibleAction implements FoldableAction {
 
     private static final Logger LOGGER = Logger.getLogger(ReleaseTriggerAction.class.getName());
-
-    @Deprecated
-    private StepContext context;
 
     /** Record of one upstream build step. */
     static class Trigger {
@@ -32,7 +30,7 @@ class ReleaseTriggerAction extends InvisibleAction implements FoldableAction {
         final StepContext context;
 
 
-        /** Record of cancellation cause passed to {@link BuildTriggerStepExecution#stop}, if any. */
+        /** Record of cancellation cause passed to {@link ReleaseStep$Execution#stop}, if any. */
         @CheckForNull Throwable interruption;
 
         Trigger(StepContext context) {
@@ -51,8 +49,6 @@ class ReleaseTriggerAction extends InvisibleAction implements FoldableAction {
     private Object readResolve() {
         if (triggers == null) {
             triggers = new ArrayList<>();
-            triggers.add(new Trigger(context));
-            context = null;
         }
         return this;
     }
@@ -73,8 +69,10 @@ class ReleaseTriggerAction extends InvisibleAction implements FoldableAction {
         if (existing == null) {
             item.addAction(this);
         } else {
-            synchronized (existing.triggers) {
-                existing.triggers.addAll(triggers);
+            if (!triggers.isEmpty()) {
+                synchronized (existing.triggers) {
+                    existing.triggers.addAll(triggers);
+                }
             }
         }
         LOGGER.log(Level.FINE, "coalescing actions for {0}", item);

--- a/src/main/java/hudson/plugins/release/pipeline/ReleaseTriggerAction.java
+++ b/src/main/java/hudson/plugins/release/pipeline/ReleaseTriggerAction.java
@@ -45,8 +45,10 @@ class ReleaseTriggerAction extends InvisibleAction {
     static Iterable<Trigger> triggersFor(Actionable actionable) {
         List<Trigger> triggers = new ArrayList<>();
         for (ReleaseTriggerAction action : actionable.getActions(ReleaseTriggerAction.class)) {
-            synchronized (action.triggers) {
-                triggers.addAll(action.triggers);
+            if (!action.triggers.isEmpty()) {
+                synchronized (action.triggers) {
+                    triggers.addAll(action.triggers);
+                }
             }
         }
         return triggers;

--- a/src/main/java/hudson/plugins/release/pipeline/ReleaseTriggerAction.java
+++ b/src/main/java/hudson/plugins/release/pipeline/ReleaseTriggerAction.java
@@ -20,9 +20,7 @@ import hudson.model.queue.FoldableAction;
  * @since 2.7
  */
 @SuppressWarnings("SynchronizeOnNonFinalField")
-class ReleaseTriggerAction extends InvisibleAction implements FoldableAction {
-    private static final Logger LOGGER = Logger.getLogger(ReleaseTriggerAction.class.getName());
-
+class ReleaseTriggerAction extends InvisibleAction {
     /** Record of one upstream build step. */
     static class Trigger {
 
@@ -52,21 +50,6 @@ class ReleaseTriggerAction extends InvisibleAction implements FoldableAction {
             }
         }
         return triggers;
-    }
-
-    @Override public void foldIntoExisting(Queue.Item item, Queue.Task owner, List<Action> otherActions) {
-        // there may be >1 upstream builds (or other unrelated causes) for a single downstream build
-        ReleaseTriggerAction existing = item.getAction(ReleaseTriggerAction.class);
-        if (existing == null) {
-            item.addAction(this);
-        } else {
-            if (!triggers.isEmpty()) {
-                synchronized (existing.triggers) {
-                    existing.triggers.addAll(triggers);
-                }
-            }
-        }
-        LOGGER.log(Level.FINE, "coalescing actions for {0}", item);
     }
 
 }

--- a/src/main/java/hudson/plugins/release/pipeline/ReleaseTriggerAction.java
+++ b/src/main/java/hudson/plugins/release/pipeline/ReleaseTriggerAction.java
@@ -1,0 +1,83 @@
+package hudson.plugins.release.pipeline;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.annotation.CheckForNull;
+
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+
+import hudson.model.Action;
+import hudson.model.Actionable;
+import hudson.model.InvisibleAction;
+import hudson.model.Queue;
+import hudson.model.queue.FoldableAction;
+
+/**
+ * copied from org.jenkinsci.plugins.workflow.support.steps.build.BuildTriggerAction
+ */
+@SuppressWarnings("SynchronizeOnNonFinalField")
+class ReleaseTriggerAction extends InvisibleAction implements FoldableAction {
+
+    private static final Logger LOGGER = Logger.getLogger(ReleaseTriggerAction.class.getName());
+
+    @Deprecated
+    private StepContext context;
+
+    /** Record of one upstream build step. */
+    static class Trigger {
+
+        final StepContext context;
+
+
+        /** Record of cancellation cause passed to {@link BuildTriggerStepExecution#stop}, if any. */
+        @CheckForNull Throwable interruption;
+
+        Trigger(StepContext context) {
+            this.context = context;
+        }
+
+    }
+
+    private /* final */ List<Trigger> triggers;
+
+    ReleaseTriggerAction(StepContext context) {
+        triggers = new ArrayList<>();
+        triggers.add(new Trigger(context));
+    }
+
+    private Object readResolve() {
+        if (triggers == null) {
+            triggers = new ArrayList<>();
+            triggers.add(new Trigger(context));
+            context = null;
+        }
+        return this;
+    }
+
+    static Iterable<Trigger> triggersFor(Actionable actionable) {
+        List<Trigger> triggers = new ArrayList<>();
+        for (ReleaseTriggerAction action : actionable.getActions(ReleaseTriggerAction.class)) {
+            synchronized (action.triggers) {
+                triggers.addAll(action.triggers);
+            }
+        }
+        return triggers;
+    }
+
+    @Override public void foldIntoExisting(Queue.Item item, Queue.Task owner, List<Action> otherActions) {
+        // there may be >1 upstream builds (or other unrelated causes) for a single downstream build
+        ReleaseTriggerAction existing = item.getAction(ReleaseTriggerAction.class);
+        if (existing == null) {
+            item.addAction(this);
+        } else {
+            synchronized (existing.triggers) {
+                existing.triggers.addAll(triggers);
+            }
+        }
+        LOGGER.log(Level.FINE, "coalescing actions for {0}", item);
+    }
+
+}

--- a/src/main/java/hudson/plugins/release/pipeline/ReleaseTriggerAction.java
+++ b/src/main/java/hudson/plugins/release/pipeline/ReleaseTriggerAction.java
@@ -21,7 +21,6 @@ import hudson.model.queue.FoldableAction;
  */
 @SuppressWarnings("SynchronizeOnNonFinalField")
 class ReleaseTriggerAction extends InvisibleAction implements FoldableAction {
-
     private static final Logger LOGGER = Logger.getLogger(ReleaseTriggerAction.class.getName());
 
     /** Record of one upstream build step. */
@@ -29,8 +28,7 @@ class ReleaseTriggerAction extends InvisibleAction implements FoldableAction {
 
         final StepContext context;
 
-
-        /** Record of cancellation cause passed to {@link ReleaseStep$Execution#stop}, if any. */
+        /** Record of cancellation cause passed to {@link ReleaseStepExecution#stop}, if any. */
         @CheckForNull Throwable interruption;
 
         Trigger(StepContext context) {
@@ -44,13 +42,6 @@ class ReleaseTriggerAction extends InvisibleAction implements FoldableAction {
     ReleaseTriggerAction(StepContext context) {
         triggers = new ArrayList<>();
         triggers.add(new Trigger(context));
-    }
-
-    private Object readResolve() {
-        if (triggers == null) {
-            triggers = new ArrayList<>();
-        }
-        return this;
     }
 
     static Iterable<Trigger> triggersFor(Actionable actionable) {

--- a/src/main/java/hudson/plugins/release/pipeline/ReleaseTriggerListener.java
+++ b/src/main/java/hudson/plugins/release/pipeline/ReleaseTriggerListener.java
@@ -1,0 +1,72 @@
+package hudson.plugins.release.pipeline;
+
+import static java.util.logging.Level.WARNING;
+
+import hudson.AbortException;
+import hudson.Extension;
+import hudson.console.ModelHyperlinkNote;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.model.listeners.RunListener;
+import java.util.logging.Level;
+
+import java.util.logging.Logger;
+
+import javax.annotation.Nonnull;
+
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper;
+
+/**
+ * copied from org.jenkinsci.plugins.workflow.support.steps.build.BuildTriggerListener
+ */
+@Extension
+public class ReleaseTriggerListener extends RunListener<Run<?,?>>{
+
+    private static final Logger LOGGER = Logger.getLogger(ReleaseTriggerListener.class.getName());
+
+    @Override
+    public void onStarted(Run<?, ?> run, TaskListener listener) {
+        for (ReleaseTriggerAction.Trigger trigger : ReleaseTriggerAction.triggersFor(run)) {
+            StepContext stepContext = trigger.context;
+            if (stepContext != null && stepContext.isReady()) {
+                LOGGER.log(Level.FINE, "started releasing {0} from #{1} in {2}", new Object[] {run, run.getQueueId(), stepContext});
+                try {
+                    TaskListener taskListener = stepContext.get(TaskListener.class);
+                    // encodeTo(Run) calls getDisplayName, which does not include the project name.
+                    taskListener.getLogger().println("Starting releasing: " + ModelHyperlinkNote.encodeTo("/" + run.getUrl(), run.getFullDisplayName()));
+                } catch (Exception e) {
+                    LOGGER.log(WARNING, null, e);
+                }
+            } else {
+                LOGGER.log(Level.FINE, "{0} unavailable in {1}", new Object[] {stepContext, run});
+            }
+        }
+    }
+
+    @Override
+    @SuppressWarnings("deprecation") // TODO 2.30+ use removeAction
+    public void onCompleted(Run<?,?> run, @Nonnull TaskListener listener) {
+        for (ReleaseTriggerAction.Trigger trigger : ReleaseTriggerAction.triggersFor(run)) {
+            LOGGER.log(Level.FINE, "completing {0} for {1}", new Object[] {run, trigger.context});
+            if (run.getResult() == Result.SUCCESS) {
+                if (trigger.interruption == null) {
+                    trigger.context.onSuccess(new RunWrapper(run, false));
+                } else {
+                    trigger.context.onFailure(trigger.interruption);
+                }
+            } else {
+                trigger.context.onFailure(new AbortException(run.getFullDisplayName() + " completed with status " + run.getResult()));
+            }
+        }
+        run.getActions().removeAll(run.getActions(ReleaseTriggerAction.class));
+    }
+
+    @Override
+    public void onDeleted(Run<?,?> run) {
+        for (ReleaseTriggerAction.Trigger trigger : ReleaseTriggerAction.triggersFor(run)) {
+            trigger.context.onFailure(new AbortException(run.getFullDisplayName() + " was deleted"));
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/release/pipeline/ReleaseTriggerListener.java
+++ b/src/main/java/hudson/plugins/release/pipeline/ReleaseTriggerListener.java
@@ -20,6 +20,7 @@ import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper;
 
 /**
  * copied from org.jenkinsci.plugins.workflow.support.steps.build.BuildTriggerListener
+ * @since 2.7
  */
 @Extension
 public class ReleaseTriggerListener extends RunListener<Run<?,?>>{

--- a/src/main/resources/hudson/plugins/release/pipeline/Messages.properties
+++ b/src/main/resources/hudson/plugins/release/pipeline/Messages.properties
@@ -1,0 +1,23 @@
+# The MIT License
+#
+# Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Seiji Sogabe, Frederic Gurr
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+ReleaseStep.DisplayName=Trigger release for the job

--- a/src/main/resources/hudson/plugins/release/pipeline/ReleaseStep/DescriptorImpl/parameters.groovy
+++ b/src/main/resources/hudson/plugins/release/pipeline/ReleaseStep/DescriptorImpl/parameters.groovy
@@ -1,0 +1,46 @@
+package hudson.plugins.release.pipeline.ReleaseStep.DescriptorImpl
+
+import hudson.model.AbstractProject
+import hudson.model.BuildableItemWithBuildWrappers
+import hudson.model.StringParameterDefinition
+import hudson.plugins.release.ReleaseWrapper;
+def st = namespace('jelly:stapler')
+def l = namespace('/lib/layout')
+l.ajax {
+    def jobName = request.getParameter('job')
+    if (jobName != null) {
+        def contextName = request.getParameter('context')
+        def context = contextName != null ? app.getItemByFullName(contextName) : null
+        def project = app.getItem(jobName, context, AbstractProject)
+
+        if (project != null) {
+            if (project instanceof BuildableItemWithBuildWrappers) {
+                def wrapper = project.getBuildWrappersList().get(ReleaseWrapper.class)
+
+                if (wrapper != null) {
+                    def parameterDefinitionList = wrapper.getParameterDefinitions()
+                    if (parameterDefinitionList.isEmpty()) {
+                        parameterDefinitionList.add(new StringParameterDefinition("RELEASE_VERSION", "", "Release version"))
+                        parameterDefinitionList.add(new StringParameterDefinition("DEVELOPMENT_VERSION", "", "Next development version"))
+                    }
+
+                    table(width: '100%', class: 'parameters') {
+                        for (parameterDefinition in parameterDefinitionList) {
+                            tbody {
+                                st.include(it: parameterDefinition, page: parameterDefinition.descriptor.valuePage)
+                            }
+                        }
+                    }
+                } else {
+                    text("${project.fullDisplayName} doesn't have release plugin configuration")
+                }
+            } else {
+                text("${project.fullDisplayName} is of wrong type and can't be released: ${project.class.simpleName}")
+            }
+        } else {
+            text("no such job ${jobName}")
+        }
+    } else {
+        text('no job specified')
+    }
+}

--- a/src/main/resources/hudson/plugins/release/pipeline/ReleaseStep/config.jelly
+++ b/src/main/resources/hudson/plugins/release/pipeline/ReleaseStep/config.jelly
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright (c) 2016 Steven G. Brown
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
+    <j:set var="jobFieldId" value="${h.generateId()}"/>
+    <f:entry field="job" title="Project to Release">
+        <f:textbox onblur="loadParams()" id="${jobFieldId}"/>
+    </f:entry>
+    <f:entry title="Parameters">
+        <div id="params"/>
+        <script>
+            function loadParams() {
+                var div = $$('params');
+                new Ajax.Request('${descriptor.descriptorUrl}/parameters?job=' + encodeURIComponent($$('${jobFieldId}').value) + '&amp;context=' + encodeURIComponent('${descriptor.context}'), {
+                    method : 'get',
+                    onSuccess : function(x) {
+                        div.innerHTML = x.responseText;
+                        Behaviour.applySubtree(div);
+                    },
+                    onFailure : function(x) {
+                        div.innerHTML = "<b>ERROR</b>: Failed to load parameter definitions: " + x.statusText;
+                    }
+                });
+            }
+        </script>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/release/pipeline/ReleaseStep/config.jelly
+++ b/src/main/resources/hudson/plugins/release/pipeline/ReleaseStep/config.jelly
@@ -26,10 +26,10 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
     <j:set var="jobFieldId" value="${h.generateId()}"/>
-    <f:entry field="job" title="Project to Release">
+    <f:entry field="job" title="${%Project to Release}">
         <f:textbox onblur="loadParams()" id="${jobFieldId}"/>
     </f:entry>
-    <f:entry title="Parameters">
+    <f:entry title="${%Parameters}">
         <div id="params"/>
         <script>
             function loadParams() {

--- a/src/main/resources/hudson/plugins/release/pipeline/ReleaseStep/config.properties
+++ b/src/main/resources/hudson/plugins/release/pipeline/ReleaseStep/config.properties
@@ -1,0 +1,24 @@
+# The MIT License
+#
+# Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Seiji Sogabe, Frederic Gurr
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+Project\ to\ Release=Project to Release
+Parameters=Parameters

--- a/src/test/java/hudson/plugins/release/pipeline/ReleaseStepTest.java
+++ b/src/test/java/hudson/plugins/release/pipeline/ReleaseStepTest.java
@@ -1,0 +1,55 @@
+package hudson.plugins.release.pipeline;
+
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
+
+import hudson.model.Action;
+import hudson.model.FreeStyleProject;
+import hudson.model.Job;
+import hudson.model.Result;
+import hudson.model.queue.QueueTaskFuture;
+import hudson.plugins.release.ReleaseWrapper;
+import jenkins.model.ParameterizedJobMixIn;
+
+/**
+ * Created by e3cmea on 1/4/17.
+ *
+ * @author Alexey Merezhin
+ */
+public class ReleaseStepTest {
+    @ClassRule
+    public static BuildWatcher buildWatcher = new BuildWatcher();
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+    @Rule public LoggerRule logging = new LoggerRule();
+
+    @Test
+    public void releaseFreeStyleProject() throws Exception {
+        FreeStyleProject ds = j.createFreeStyleProject("ds");
+        ds.getBuildWrappersList().add(new ReleaseWrapper());
+        WorkflowJob us = j.jenkins.createProject(WorkflowJob.class, "us");
+        us.setDefinition(new CpsFlowDefinition("release 'ds'\n echo \"release's done\"", true));
+        j.assertLogContains("release's done", j.buildAndAssertSuccess(us));
+        ds.getBuildByNumber(1).delete();
+    }
+
+    @Test
+    public void failForJobWithoutRelease() throws Exception {
+        FreeStyleProject ds = j.createFreeStyleProject("ds");
+        final WorkflowJob us = j.jenkins.createProject(WorkflowJob.class, "us");
+        us.setDefinition(new CpsFlowDefinition("release 'ds'\n echo \"release's done\"", true));
+        QueueTaskFuture f = (new ParameterizedJobMixIn() {
+            protected Job asJob() {
+                return us;
+            }
+        }).scheduleBuild2(0, new Action[0]);
+        j.assertBuildStatus(Result.FAILURE, f);
+    }
+
+}


### PR DESCRIPTION
Pipeline support is added to release plugin. Release can be triggered from pipeline as following:
`release job: 'jobname' `

I was using pipeline-build-step-plugin as a reference.
