### PR TITLE
[JENKINS-40765] - Apply some fixes after the manual testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.15</version>
+    <version>2.24</version>
   </parent>
   <artifactId>release</artifactId>
   <packaging>hpi</packaging>
@@ -16,6 +16,7 @@
   <properties>
     <!-- https://issues.jenkins-ci.org/browse/JENKINS-29692  https://issues.jenkins-ci.org/browse/JENKINS-28781 -->
     <jenkins.version>1.642.4</jenkins.version>
+    <java.level>7</java.level>
   </properties>
 
   <scm>

--- a/src/main/java/hudson/plugins/release/pipeline/ReleaseStep.java
+++ b/src/main/java/hudson/plugins/release/pipeline/ReleaseStep.java
@@ -47,6 +47,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * @author Alexey Merezhin
  * @since 2.7
  */
+@Restricted(NoExternalUse.class)
 public class ReleaseStep extends Step {
     private static final Logger LOGGER = Logger.getLogger(ReleaseStep.class.getName());
 

--- a/src/main/java/hudson/plugins/release/pipeline/ReleaseStepExecution.java
+++ b/src/main/java/hudson/plugins/release/pipeline/ReleaseStepExecution.java
@@ -29,11 +29,14 @@ import hudson.plugins.release.ReleaseWrapper;
 import hudson.plugins.release.SafeParametersAction;
 import jenkins.model.Jenkins;
 import jenkins.model.ParameterizedJobMixIn;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * @author Alexey Merezhin
  * @since 2.7
  */
+@Restricted(NoExternalUse.class)
 public class ReleaseStepExecution extends StepExecution {
     private static final Logger LOGGER = Logger.getLogger(ReleaseStepExecution.class.getName());
 

--- a/src/main/java/hudson/plugins/release/pipeline/ReleaseStepExecution.java
+++ b/src/main/java/hudson/plugins/release/pipeline/ReleaseStepExecution.java
@@ -18,6 +18,7 @@ import hudson.model.Action;
 import hudson.model.BuildableItemWithBuildWrappers;
 import hudson.model.Cause;
 import hudson.model.CauseAction;
+import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.ParameterDefinition;
 import hudson.model.ParameterValue;
@@ -63,7 +64,7 @@ public class ReleaseStepExecution extends StepExecution {
                     }
                 }
             } else {
-                throw new AbortException("Job doesn't have release plugin configuration");
+                throw new AbortException("Job doesn't have the Release plugin configuration");
             }
         }
         return parameters;
@@ -71,31 +72,36 @@ public class ReleaseStepExecution extends StepExecution {
 
     @Override
     public boolean start() throws Exception {
-        if (step.getJob() == null) {
+        final String jobFullName = step.getJob();
+        if (jobFullName == null) {
             throw new AbortException("Job name is not defined.");
         }
 
-        final ParameterizedJobMixIn.ParameterizedJob project = Jenkins.getActiveInstance().
-                getItemByFullName(step.getJob(), ParameterizedJobMixIn.ParameterizedJob.class);;
-        if (project == null) {
-            throw new AbortException("No parametrized job named " + step.getJob() + " found");
-        }
-        println("Releasing project: " + ModelHyperlinkNote.encodeTo(project));
+        final Item itemToRun = Jenkins.getActiveInstance().getItemByFullName(jobFullName);
+        if (itemToRun == null) {
+            throw new AbortException("No item found: " + jobFullName );
+        } else if (!(itemToRun instanceof Job<?, ?> && itemToRun instanceof ParameterizedJobMixIn.ParameterizedJob)) {
+            throw new AbortException("The specified item is not a parameterizable job: " + jobFullName );
+        } 
+        
+        final ParameterizedJobMixIn.ParameterizedJob jobToRun = (ParameterizedJobMixIn.ParameterizedJob) itemToRun;
+        println("Releasing job: " + ModelHyperlinkNote.encodeTo(jobToRun));
 
-        LOGGER.log(Level.FINER, "scheduling a release of {0} from {1}", new Object[] { project, getContext() });
+        LOGGER.log(Level.FINER, "Scheduling release of {0} from {1}", new Object[] { jobToRun, getContext() });
         Run run = getContext().get(Run.class);
         List<Action> actions = new ArrayList<>(3);
         actions.add(new ReleaseTriggerAction(getContext()));
         actions.add(new ReleaseWrapper.ReleaseBuildBadgeAction());
-        actions.add(new SafeParametersAction(updateParametersWithDefaults(project, step.getParameters())));
+        actions.add(new SafeParametersAction(updateParametersWithDefaults(jobToRun, step.getParameters())));
         if (run != null) {
             actions.add(new CauseAction(new Cause.UpstreamCause(run)));
         }
 
-        Queue.Item item = ParameterizedJobMixIn.scheduleBuild2((Job<?, ?>) project, 0, actions.toArray(new Action[0]));
+        Queue.Item item = ParameterizedJobMixIn.scheduleBuild2((Job<?, ?>)jobToRun, 0, 
+                actions.toArray(new Action[0]));
 
         if (item == null || item.getFuture() == null) {
-            throw new AbortException("Failed to trigger build of " + project.getFullName());
+            throw new AbortException("Failed to trigger build of " + jobToRun.getFullName());
         }
 
         return false;

--- a/src/main/java/hudson/plugins/release/pipeline/ReleaseTriggerAction.java
+++ b/src/main/java/hudson/plugins/release/pipeline/ReleaseTriggerAction.java
@@ -9,11 +9,14 @@ import org.jenkinsci.plugins.workflow.steps.StepContext;
 
 import hudson.model.Actionable;
 import hudson.model.InvisibleAction;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * copied from org.jenkinsci.plugins.workflow.support.steps.build.BuildTriggerAction
  * @since 2.7
  */
+@Restricted(NoExternalUse.class)
 class ReleaseTriggerAction extends InvisibleAction {
     /** Record of one upstream build step. */
     static class Trigger {

--- a/src/main/java/hudson/plugins/release/pipeline/ReleaseTriggerListener.java
+++ b/src/main/java/hudson/plugins/release/pipeline/ReleaseTriggerListener.java
@@ -17,12 +17,15 @@ import javax.annotation.Nonnull;
 
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * copied from org.jenkinsci.plugins.workflow.support.steps.build.BuildTriggerListener
  * @since 2.7
  */
 @Extension
+@Restricted(NoExternalUse.class)
 public class ReleaseTriggerListener extends RunListener<Run<?,?>>{
 
     private static final Logger LOGGER = Logger.getLogger(ReleaseTriggerListener.class.getName());

--- a/src/main/resources/hudson/plugins/release/pipeline/ReleaseStep/DescriptorImpl/parameters.groovy
+++ b/src/main/resources/hudson/plugins/release/pipeline/ReleaseStep/DescriptorImpl/parameters.groovy
@@ -1,17 +1,19 @@
 package hudson.plugins.release.pipeline.ReleaseStep.DescriptorImpl
 
-import hudson.model.AbstractProject
+import hudson.model.Item
 import hudson.model.BuildableItemWithBuildWrappers
 import hudson.model.StringParameterDefinition
 import hudson.plugins.release.ReleaseWrapper;
 def st = namespace('jelly:stapler')
 def l = namespace('/lib/layout')
+//TODO: add support of warnings
+//TODO: support of folders???
 l.ajax {
     def jobName = request.getParameter('job')
     if (jobName != null) {
         def contextName = request.getParameter('context')
         def context = contextName != null ? app.getItemByFullName(contextName) : null
-        def project = app.getItem(jobName, context, AbstractProject)
+        def project = app.getItem(jobName, context, Item)
 
         if (project != null) {
             if (project instanceof BuildableItemWithBuildWrappers) {
@@ -32,15 +34,16 @@ l.ajax {
                         }
                     }
                 } else {
-                    text("${project.fullDisplayName} doesn't have release plugin configuration")
+                    text("${project.fullDisplayName} does not have the release configuration")
                 }
             } else {
-                text("${project.fullDisplayName} is of wrong type and can't be released: ${project.class.simpleName}")
+                text("${project.fullDisplayName} is of wrong type and can't be released: " +
+                     "(${project.class.simpleName} does not implement BuildableItemWithBuildWrappers)")
             }
         } else {
-            text("no such job ${jobName}")
+            text("No such item ${jobName}")
         }
     } else {
-        text('no job specified')
+        text('No item specified')
     }
 }

--- a/src/main/resources/hudson/plugins/release/pipeline/ReleaseStep/config.jelly
+++ b/src/main/resources/hudson/plugins/release/pipeline/ReleaseStep/config.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
     <j:set var="jobFieldId" value="${h.generateId()}"/>
-    <f:entry field="job" title="${%Project to Release}">
+    <f:entry field="job" title="${%Job to Release}">
         <f:textbox onblur="loadParams()" id="${jobFieldId}"/>
     </f:entry>
     <f:entry title="${%Parameters}">

--- a/src/main/resources/hudson/plugins/release/pipeline/ReleaseStep/config.properties
+++ b/src/main/resources/hudson/plugins/release/pipeline/ReleaseStep/config.properties
@@ -20,5 +20,5 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-Project\ to\ Release=Project to Release
+Job\ to\ Release=Job to Release
 Parameters=Parameters

--- a/src/main/resources/hudson/plugins/release/pipeline/ReleaseStep/help-job.html
+++ b/src/main/resources/hudson/plugins/release/pipeline/ReleaseStep/help-job.html
@@ -1,0 +1,5 @@
+<div>
+  Full name of the job to be released.
+  This job must be visible to the current user.
+  It should contain the Release configuration defined by the plugin.
+</div>


### PR DESCRIPTION
It is a follow-up to #22

- [x] Restore the `SafeParameterAction` implementation  to restore the SECURITY-170 hack made by @amuniz 
- [x] Fix handling of Folders in the `release()` step. Now all the logic operates with absolute paths. Support of relative paths can be added later once I unravel the Promoted Builds plugin with this feature
- [x] Fix notification for improper item types in `properties.groovy`
- [x] Restrict all new API just in case we need to rework them

https://issues.jenkins-ci.org/browse/JENKINS-40765

@reviewbybees @estarter @mustafau 