### PR TITLE
[JENKINS-43490] Add wait parameter to release function

### DIFF
--- a/src/main/java/hudson/plugins/release/pipeline/ReleaseStep.java
+++ b/src/main/java/hudson/plugins/release/pipeline/ReleaseStep.java
@@ -59,6 +59,7 @@ public class ReleaseStep extends Step {
     private String job;
     @Nonnull
     private List<ParameterValue> parameters;
+    private boolean wait = true;
 
     @DataBoundConstructor
     public ReleaseStep(String job) {
@@ -93,6 +94,15 @@ public class ReleaseStep extends Step {
         } else {
             this.parameters = parameters;
         }
+    }
+
+    public boolean getWait() {
+        return wait;
+    }
+
+    @DataBoundSetter
+    public void setWait(boolean wait) {
+        this.wait = wait;
     }
 
     @Override

--- a/src/main/java/hudson/plugins/release/pipeline/ReleaseStepExecution.java
+++ b/src/main/java/hudson/plugins/release/pipeline/ReleaseStepExecution.java
@@ -107,7 +107,12 @@ public class ReleaseStepExecution extends StepExecution {
             throw new AbortException("Failed to trigger build of " + jobToRun.getFullName());
         }
 
-        return false;
+        if (step.getWait()) {
+            return false;
+        } else {
+            getContext().onSuccess(null);
+            return true;
+        }
     }
 
     private void println(String message) throws IOException, InterruptedException {

--- a/src/main/resources/hudson/plugins/release/pipeline/ReleaseStep/config.jelly
+++ b/src/main/resources/hudson/plugins/release/pipeline/ReleaseStep/config.jelly
@@ -29,6 +29,9 @@ THE SOFTWARE.
     <f:entry field="job" title="${%Job to Release}">
         <f:textbox onblur="loadParams()" id="${jobFieldId}"/>
     </f:entry>
+    <f:entry field="wait">
+        <f:checkbox default="true" title="Wait for completion"/>
+    </f:entry>
     <f:entry title="${%Parameters}">
         <div id="params"/>
         <script>

--- a/src/main/resources/hudson/plugins/release/pipeline/ReleaseStep/help-wait.groovy
+++ b/src/main/resources/hudson/plugins/release/pipeline/ReleaseStep/help-wait.groovy
@@ -1,0 +1,10 @@
+p(raw('''
+    You may ask that this Pipeline build wait for completion of the downstream build.
+    In that case the return value of the step is an object on which you can obtain the following read-only properties:
+    so you can inspect its <code>.result</code> and so on.
+'''))
+raw(org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper.class.getResource("RunWrapper/help.html").text)
+p('''
+    If you do not wait, this step succeeds so long as the downstream build can be added to the queue (it will not even have been started).
+    In that case there is currently no return value.
+''')

--- a/src/test/java/hudson/plugins/release/pipeline/ReleaseStepTest.java
+++ b/src/test/java/hudson/plugins/release/pipeline/ReleaseStepTest.java
@@ -12,6 +12,7 @@ import org.jvnet.hudson.test.LoggerRule;
 import hudson.model.Action;
 import hudson.model.FreeStyleProject;
 import hudson.model.Job;
+import hudson.model.Label;
 import hudson.model.Result;
 import hudson.model.queue.QueueTaskFuture;
 import hudson.plugins.release.ReleaseWrapper;
@@ -52,4 +53,13 @@ public class ReleaseStepTest {
         j.assertBuildStatus(Result.FAILURE, f);
     }
 
+    @Test
+    public void noWait() throws Exception {
+        FreeStyleProject ds = j.createFreeStyleProject("ds");
+        ds.setAssignedLabel(Label.get("nonexistent"));
+        ds.getBuildWrappersList().add(new ReleaseWrapper());
+        WorkflowJob us = j.jenkins.createProject(WorkflowJob.class, "us");
+        us.setDefinition(new CpsFlowDefinition("release job: 'ds', wait: false"));
+        j.buildAndAssertSuccess(us);
+    }
 }


### PR DESCRIPTION
Adds ability to **not** wait until downstream job finishes.