### PR TITLE
JENKINS-53994 Parameters that use own descriptor to check/fill fields returns 404 in schedule release page

### DIFF
--- a/src/main/java/hudson/plugins/release/ReleaseWrapper.java
+++ b/src/main/java/hudson/plugins/release/ReleaseWrapper.java
@@ -724,6 +724,10 @@ public class ReleaseWrapper extends BuildWrapper implements MatrixAggregatable {
 			return RELEASE;
 		}
 
+	    public Descriptor<?> getDescriptorByName(String className) {
+	        return project.getDescriptorByName(className);
+	    }
+
     }
     
     public static class ReleaseBuildBadgeAction implements BuildBadgeAction, MatrixChildAction {


### PR DESCRIPTION
Add method getDescriptorByName to the release action class that rely the requested descriptor to the project.

After changes
![image](https://user-images.githubusercontent.com/4160180/46753134-44ce7100-ccbf-11e8-8f48-c4cf23c55d60.png)
